### PR TITLE
Update PHP version in classic web server documentation

### DIFF
--- a/src/content/documentation/classic-web-server.mdx
+++ b/src/content/documentation/classic-web-server.mdx
@@ -22,7 +22,7 @@ server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
         fastcgi_index index.php;
         include fastcgi.conf;
     }


### PR DESCRIPTION
This is a similar pull request to https://github.com/shlinkio/shlink/pull/691 - all it does is update the PHP version listed in a single file from 7.2 to 7.4, as Shlink 2.0 and above require PHP version 7.4 or above.