### PR TITLE
Minor correction for docker installation docs

### DIFF
--- a/src/content/documentation/install-docker-image.mdx
+++ b/src/content/documentation/install-docker-image.mdx
@@ -9,7 +9,7 @@ There are two "flavors", [openswoole](https://openswoole.com/)-based and [RoadRu
 <Callout type="info">
   Shlink docker images are published both in [Docker hub](https://hub.docker.com/r/shlinkio/shlink) and [Github Container Registry](https://github.com/shlinkio/shlink/pkgs/container/shlink).
 
-  In order to install images from the former, use `ghcr.io/shlinkio/shlink` instead of `shlinkio/shlink`.
+  In order to install images from the latter, use `ghcr.io/shlinkio/shlink` instead of `shlinkio/shlink`.
 </Callout>
 
 ### Usage


### PR DESCRIPTION
The github link is the second one, but the next line refers to it as former rather than latter.