### PR TITLE
Fix cron specification

### DIFF
--- a/src/content/documentation/long-running-tasks.mdx
+++ b/src/content/documentation/long-running-tasks.mdx
@@ -31,6 +31,6 @@ Shlink locates visits automatically just before redirecting end users. However, 
 One way to schedule any of the previous tasks is by making use of Unix cron jobs:
 
 * Locate visits every hour: `0 * * * * /path/to/shlink/bin/cli visit:locate -q -n`
-* Update the GeoLite2 db every 7 days: `* * 7 * * /path/to/shlink/bin/cli visit:download-db -q -n`
+* Update the GeoLite2 db every 7 days: `0 0 * * 0 /path/to/shlink/bin/cli visit:download-db -q -n`
 
 *The `-q` and `-n` flags are available on any Shlink command. The first one will discard any output, and the second one ensure the command is run in a non-interactive mode.*


### PR DESCRIPTION
Prev: `* * 7 * *` is interpreted as ["at every minute on the 7th of every month"](https://crontab.guru/#*_*_7_*_*) instead of once a week

This PR replaces it with `0 0 * * 0` (interpreted as ["at midnight on every Sunday"](https://crontab.guru/#0_0_*_*_0)), which is what the documentation states