### PR TITLE
Fix typo in Docs about API health endpoint

### DIFF
--- a/src/pages/documentation/some-features.mdx
+++ b/src/pages/documentation/some-features.mdx
@@ -165,6 +165,6 @@ The image is effectively invisible, but every time the email is opened and the i
 
 In some situations you may want to know if your Shlink instance is healthy. Reasons might include monitoring, but also letting orchestrators know if one specific instance can respond to requests.
 
-Shlink exposes a `/rest/heath` endpoint, which does not require authentication, and can be used for this purpose.
+Shlink exposes a `/rest/health` endpoint, which does not require authentication, and can be used for this purpose.
 
 You can find more information in the [API docs](https://api-spec.shlink.io/#/Monitoring/health).


### PR DESCRIPTION
Fix typo `heath` -> `health`

https://shlink.io/documentation/some-features/#service-healthiness