### PR TITLE
Fix wrong port in documentation

### DIFF
--- a/src/pages/documentation/shlink-web-client/pre-configuring-servers.mdx
+++ b/src/pages/documentation/shlink-web-client/pre-configuring-servers.mdx
@@ -66,7 +66,7 @@ If you are using the shlink-web-client docker image, you can also pre-configure 
   ```shell
   docker run \
     --name shlink-web-client \
-    -p 8000:80 \
+    -p 8000:8080 \
     -e SHLINK_SERVER_URL=https://s.test \
     -e SHLINK_SERVER_API_KEY=6aeb82c6-e275-4538-a747-31f9abfba63c \
     shlinkio/shlink-web-client


### PR DESCRIPTION
Documentation was not updated completely (see PR #573)

Caused by 44d4c21679178c7f39c18601f16709624ed9ae57
Fixes #600