### PR TITLE
Fix GeoLite2 links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [7.11.1] - 2024-10-12
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* Fix GeoLite2 links
+
+
 ## [7.11.0] - 2024-10-04
 ### Added
 * Document support for redis database index.

--- a/src/pages/documentation/geolite-license-key.mdx
+++ b/src/pages/documentation/geolite-license-key.mdx
@@ -9,7 +9,7 @@ export const components = markdownComponents
 
 ## GeoLite2 license key
 
-Shlink makes use of a [GeoLite2](https://dev.maxmind.com/geoip/geoip2/geolite2/) database, by [MaxMind](https://www.maxmind.com), to geolocate visits to your short URLs.
+Shlink makes use of a [GeoLite2](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data/) database, by [MaxMind](https://www.maxmind.com), to geolocate visits to your short URLs.
 
 To make sure the data is always up-to-date, it downloads new versions of the database regularly.
 

--- a/src/pages/documentation/tracking-visits.mdx
+++ b/src/pages/documentation/tracking-visits.mdx
@@ -14,7 +14,7 @@ Shlink will track every time your short URLs are opened, and then try to geoloca
 
 ### Considerations
 
-In order to geolocate visits, Shlink makes use of a [GeoLite2](https://dev.maxmind.com/geoip/geoip2/geolite2/) database, by [MaxMind](https://www.maxmind.com), which is used to match the location of the visitor's IP address.
+In order to geolocate visits, Shlink makes use of a [GeoLite2](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data/) database, by [MaxMind](https://www.maxmind.com), which is used to match the location of the visitor's IP address.
 
 To make sure your GeoLite2 db is always up-to-date, you will have to [configure your own license key](/documentation/geolite-license-key).
 


### PR DESCRIPTION
GeoLite2 links have changed, and the ones referenced in this site now return a 404. This PR replaces them with the new ones.