### PR TITLE
Replace classnames package with clsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "astro-expressive-code": "^0.40.2",
         "astro-seo": "^0.8.4",
         "bootstrap": "^5.3.3",
-        "classnames": "^2.5.1",
+        "clsx": "^2.1.1",
         "mdx-mermaid": "^2.0.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -6588,11 +6588,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
-    },
     "node_modules/cli-boxes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
@@ -6621,6 +6616,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -27783,11 +27779,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
       "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A=="
-    },
-    "classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "cli-boxes": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "astro-expressive-code": "^0.40.2",
     "astro-seo": "^0.8.4",
     "bootstrap": "^5.3.3",
-    "classnames": "^2.5.1",
+    "clsx": "^2.1.1",
     "mdx-mermaid": "^2.0.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/components/Callout.tsx
+++ b/src/components/Callout.tsx
@@ -1,6 +1,6 @@
 import { faBullhorn, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import type { FC, PropsWithChildren } from 'react';
 
 type CalloutType = 'info' | 'warning';
@@ -23,7 +23,7 @@ const TYPE_MAP: Record<CalloutType, any> = {
 };
 
 export const Callout: FC<CalloutProps> = ({ children, type, title }) => (
-  <div className={classNames('callout-block', TYPE_MAP[type].className)}>
+  <div className={clsx('callout-block', TYPE_MAP[type].className)}>
     <div className="content">
       <h4 className="callout-title">
         <span className="callout-icon-holder me-2">

--- a/src/components/DocsMenu.tsx
+++ b/src/components/DocsMenu.tsx
@@ -1,7 +1,7 @@
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faArrowUpRightFromSquare, faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import type { FC, PropsWithChildren } from 'react';
 import { Fragment, useState } from 'react';
 import type { Route } from '../utils/docUtils';
@@ -17,8 +17,8 @@ type MenuItemProps = PropsWithChildren<{
 }>;
 
 const MenuItem: FC<MenuItemProps> = ({ active, link, children, icon, isOpen, onChevronClick }) => (
-  <li className={classNames('nav-item', { 'section-title': icon })}>
-    <Link className={classNames('nav-link', { active })} href={link}>
+  <li className={clsx('nav-item', { 'section-title': icon })}>
+    <Link className={clsx('nav-link', { active })} href={link}>
       {icon && <span className="theme-icon-holder me-2"><FontAwesomeIcon icon={icon} /></span>}
       {children}
       {link.startsWith('http') && <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="ms-2" />}

--- a/src/components/DocsSidebar.tsx
+++ b/src/components/DocsSidebar.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import clsx from 'clsx';
 import type { FC, PropsWithChildren } from 'react';
 import { useCallback, useState } from 'react';
 import { DocsMenu } from './DocsMenu';
@@ -28,7 +28,7 @@ export const DocsSidebar: FC<DocsSidebarProps> = ({ currentPage, children }) => 
   return (
     <>
       <NavbarToggler onClick={toggleSidebar} collapsed={sidebarState !== 'displayed'} className="docs-menu-toggle" />
-      <div className={classNames('docs-sidebar', classesForState(sidebarState))}>
+      <div className={clsx('docs-sidebar', classesForState(sidebarState))}>
         <div className="p-3" style={{ height: '68px' }}>
           {children}
         </div>

--- a/src/components/Feature.tsx
+++ b/src/components/Feature.tsx
@@ -1,6 +1,6 @@
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import type { FC, PropsWithChildren } from 'react';
 import { Link } from './Link';
 
@@ -12,7 +12,7 @@ type FeatureProps = PropsWithChildren<{
 }>;
 
 export const Feature: FC<FeatureProps> = ({ title, children, link, icon, className }) => (
-  <div className={classNames('item col-12 col-md-6 col-lg-3', className)}>
+  <div className={clsx('item col-12 col-md-6 col-lg-3', className)}>
     <div className="item-inner rounded">
       <div className="icon-holder text-center mx-auto mb-3">
         <FontAwesomeIcon icon={icon} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import clsx from 'clsx';
 import type { FC, PropsWithChildren } from 'react';
 import { useCallback, useState } from 'react';
 import { InternalLink } from './InternalLink';
@@ -12,7 +12,7 @@ type MenuItemProps = PropsWithChildren<{
 }>;
 
 const MenuItem: FC<MenuItemProps> = ({ to, children, isLast, active }) => (
-  <li className={classNames('nav-item', { 'me-lg-0': isLast, 'me-lg-4': !isLast, active })}>
+  <li className={clsx('nav-item', { 'me-lg-0': isLast, 'me-lg-4': !isLast, active })}>
     <InternalLink href={to} className="nav-link">{children}</InternalLink>
   </li>
 );
@@ -34,7 +34,7 @@ export const Header: FC<HeaderProps> = ({ leftMenuToggle, currentPage }) => {
       <div className="container-fluid position-relative">
         <nav className="navbar navbar-expand-lg">
           <div className="container-fluid">
-            <div className={classNames('site-logo', { 'site-logo__mobile': leftMenuToggle })}>
+            <div className={clsx('site-logo', { 'site-logo__mobile': leftMenuToggle })}>
               <InternalLink href="/" className="navbar-brand">
                 <img
                   className="logo-icon me-2"
@@ -47,7 +47,7 @@ export const Header: FC<HeaderProps> = ({ leftMenuToggle, currentPage }) => {
 
             <NavbarToggler collapsed={collapsed} onClick={toggleCollapsed}/>
 
-            <div className={classNames('collapse navbar-collapse', { show: !collapsed })}>
+            <div className={clsx('collapse navbar-collapse', { show: !collapsed })}>
               <SocialList type="inline" className="mt-3 mt-lg-0 mb-lg-0 d-flex ms-lg-5 me-lg-5"/>
 
               <ul className="navbar-nav ms-lg-auto">

--- a/src/components/NavbarToggler.tsx
+++ b/src/components/NavbarToggler.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import clsx from 'clsx';
 import type { FC } from 'react';
 
 export type NavbarTogglerProps = {
@@ -10,7 +10,7 @@ export type NavbarTogglerProps = {
 export const NavbarToggler: FC<NavbarTogglerProps> = ({ collapsed, onClick, className }) => (
   <button
     aria-label="Toggle navigation"
-    className={classNames('navbar-toggler', className, { collapsed })}
+    className={clsx('navbar-toggler', className, { collapsed })}
     onClick={onClick}
   >
     <span/>

--- a/src/components/SectionItem.tsx
+++ b/src/components/SectionItem.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import clsx from 'clsx';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
 
 export type SectionItemProps = PropsWithChildren<{
@@ -10,7 +10,7 @@ export type SectionItemProps = PropsWithChildren<{
 export const SectionItem: FC<SectionItemProps> = ({ title, children, block, reverse }) => (
   <div className="item py-4 py-md-5">
     <div className="row">
-      <div className={classNames('col-12 col-md-5 mb-3 mb-md-0 align-self-center', { 'order-md-1 ps-md-5': reverse })}>
+      <div className={clsx('col-12 col-md-5 mb-3 mb-md-0 align-self-center', { 'order-md-1 ps-md-5': reverse })}>
         <div className="content pe-5">
           <h3 className="heading">{title}</h3>
           <div className="desc">{children}</div>

--- a/src/components/SocialList.tsx
+++ b/src/components/SocialList.tsx
@@ -1,6 +1,6 @@
 import { faBluesky, faGithub, faMastodon, faPaypal } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import type { FC } from 'react';
 import { ExternalLink } from 'react-external-link';
 
@@ -10,7 +10,7 @@ interface SocialListProps {
 }
 
 export const SocialList: FC<SocialListProps> = ({ type, className }) => (
-  <ul className={classNames(`social-list list-${type}`, className)}>
+  <ul className={clsx(`social-list list-${type}`, className)}>
     <li className="list-inline-item">
       <ExternalLink href="https://github.com/shlinkio/shlink" title="GitHub" aria-label="GitHub">
         <FontAwesomeIcon icon={faGithub} fixedWidth />


### PR DESCRIPTION
Remove `classnames` module, and replace it with the more modern `clsx` one.

This also has the benefit that Astro depends on clsx already, so this only removes a dependency and adds nothing new.