### PR TITLE
Add deprecation warning about QR codes

### DIFF
--- a/src/pages/documentation/environment-variables.mdx
+++ b/src/pages/documentation/environment-variables.mdx
@@ -90,6 +90,10 @@ Strikethrough env vars are deprecated.
 
 #### QR codes
 
+<Callout type="warning">
+  Generating QR Codes through Shlink is being deprecated (see <a href="https://github.com/shlinkio/shlink/issues/2408">#2408</a>).
+</Callout>
+
 * `DEFAULT_QR_CODE_SIZE`: A value between 50 and 1000 to determine the default size of generated QR codes when the `size` query param is not provided. Defaults to 300.
 * `DEFAULT_QR_CODE_MARGIN`: A value greater than 0 to determine the default margin of generated QR codes when the `margin` query param is not provided. Defaults to 0.
 * `DEFAULT_QR_CODE_FORMAT`: One of **png** or **svg**, to determine the default format of generated QR codes when the `format` query param is not provided. Defaults to png.

--- a/src/pages/documentation/environment-variables.mdx
+++ b/src/pages/documentation/environment-variables.mdx
@@ -91,7 +91,7 @@ Strikethrough env vars are deprecated.
 #### QR codes
 
 <Callout type="warning">
-  Generating QR Codes through Shlink is being deprecated (see <a href="https://github.com/shlinkio/shlink/issues/2408">#2408</a>).
+  Generating QR codes through Shlink is being deprecated. See [this issue](https://github.com/shlinkio/shlink/issues/2408) for details.
 </Callout>
 
 * `DEFAULT_QR_CODE_SIZE`: A value between 50 and 1000 to determine the default size of generated QR codes when the `size` query param is not provided. Defaults to 300.

--- a/src/pages/documentation/install-dist-file.mdx
+++ b/src/pages/documentation/install-dist-file.mdx
@@ -14,7 +14,7 @@ If you are going to host Shlink yourself, you need to make sure your server fulf
 * PHP 8.3 or 8.4
 * The next PHP extensions: json, curl, pdo, intl, gd and gmp/bcmath.
     * apcu extension is recommended if you don't plan to use RoadRunner.
-    * xml extension is required if you want to generate QR codes in svg format. (QR code generation is being deprecated, see [#2408](https://github.com/shlinkio/shlink/issues/2408))
+    * xml extension is required if you want to generate QR codes in svg format. (QR code generation is being deprecated, see [this issue](https://github.com/shlinkio/shlink/issues/2408) for details)
     * sockets and bcmath extensions are required if you want to integrate with a RabbitMQ instance, or use [RoadRunner to serve Shlink](/documentation/supported-runtimes/serve-with-roadrunner/).
 * MySQL, MariaDB, PostgreSQL, MicrosoftSQL or SQLite.
     * You will also need the corresponding pdo variation for the database you are planning to use: `pdo_mysql`, `pdo_pgsql` or `pdo_sqlsrv`.

--- a/src/pages/documentation/install-dist-file.mdx
+++ b/src/pages/documentation/install-dist-file.mdx
@@ -14,7 +14,7 @@ If you are going to host Shlink yourself, you need to make sure your server fulf
 * PHP 8.3 or 8.4
 * The next PHP extensions: json, curl, pdo, intl, gd and gmp/bcmath.
     * apcu extension is recommended if you don't plan to use RoadRunner.
-    * xml extension is required if you want to generate QR codes in svg format.
+    * xml extension is required if you want to generate QR codes in svg format. (QR code generation is being deprecated, see [#2408](https://github.com/shlinkio/shlink/issues/2408))
     * sockets and bcmath extensions are required if you want to integrate with a RabbitMQ instance, or use [RoadRunner to serve Shlink](/documentation/supported-runtimes/serve-with-roadrunner/).
 * MySQL, MariaDB, PostgreSQL, MicrosoftSQL or SQLite.
     * You will also need the corresponding pdo variation for the database you are planning to use: `pdo_mysql`, `pdo_pgsql` or `pdo_sqlsrv`.

--- a/src/pages/documentation/some-features.mdx
+++ b/src/pages/documentation/some-features.mdx
@@ -109,6 +109,10 @@ This is achieved via the so called `loose` short URL mode (the mode can be set v
 
 Shlink comes with built-in support to generate QR codes for any short URL.
 
+<Callout type="warning">
+  Generating QR Codes through Shlink is being deprecated (see <a href="https://github.com/shlinkio/shlink/issues/2408">#2408</a>).
+</Callout>
+
 Getting a QR code URL is as simple as appending `/qr-code` to any short URL. So if your short URL is `https://exam.ple/abc123`, the URL which returns the binary QR code image is `https://exam.ple/abc123/qr-code`.
 
 The image's default appearance can be customized via [installation tool](/documentation/command-line-interface/installation-tool) or [env vars](/documentation/environment-variables#qr-codes), but it can also be customized on the fly via query params:

--- a/src/pages/documentation/some-features.mdx
+++ b/src/pages/documentation/some-features.mdx
@@ -110,7 +110,7 @@ This is achieved via the so called `loose` short URL mode (the mode can be set v
 Shlink comes with built-in support to generate QR codes for any short URL.
 
 <Callout type="warning">
-  Generating QR Codes through Shlink is being deprecated (see <a href="https://github.com/shlinkio/shlink/issues/2408">#2408</a>).
+  Generating QR codes through Shlink is being deprecated. See [this issue](https://github.com/shlinkio/shlink/issues/2408) for details.
 </Callout>
 
 Getting a QR code URL is as simple as appending `/qr-code` to any short URL. So if your short URL is `https://exam.ple/abc123`, the URL which returns the binary QR code image is `https://exam.ple/abc123/qr-code`.


### PR DESCRIPTION
I thought adding a deprecation warning about QR codes could make sense so that users are not integrating the QR codes any more and/or integrating them into their workflows.

Thanks for this great application!